### PR TITLE
Ajout d'un script de setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@ Ce dépôt contient les documents et le squelette de code pour un programme d'au
 Le dossier `paris_sportifs_crypto` présente la structure initiale décrite dans la documentation.
 Vous y trouverez un backend (API, analyse, base de données, utilitaires) et un frontend minimal.
 
-Pour lancer un test rapide :
+## Mise en place de l'environnement
+
+Avant de lancer le programme, exécutez le script `setup.sh` pour installer les dépendances nécessaires et vérifier l'accès réseau :
+
+```bash
+./setup.sh
+```
+
+## Lancer un test rapide
+
+Après la mise en place, vous pouvez lancer un test rapide :
 
 ```bash
 python paris_sportifs_crypto/main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Script d'installation des dependances pour l'environnement Codex
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Ce script doit etre execute en tant que root" >&2
+  exit 1
+fi
+
+# Mise a jour et installation de pip si necessaire
+echo "[Setup] Installation de python3-pip"
+apt-get update && apt-get install -y python3-pip curl
+
+# Mise a niveau de pip et installation des dependances Python
+echo "[Setup] Installation des dependances Python"
+pip3 install --upgrade pip
+if [ -f requirements.txt ]; then
+  pip3 install -r requirements.txt
+fi
+
+# Test rapide de la connectivite reseau
+if curl -I https://example.com > /dev/null 2>&1; then
+  echo "[Setup] Acces reseau verifie avec succes"
+else
+  echo "[Setup] Impossible de joindre Internet" >&2
+fi
+
+echo "[Setup] Terminé"


### PR DESCRIPTION
## Notes
- Ajout d'un script `setup.sh` pour installer les dépendances et vérifier la connectivité réseau.
- Création d'un `requirements.txt` minimal (module `requests`).
- Documentation mise à jour avec la nouvelle section de mise en place.

## Testing
- `bash setup.sh` *(échec : pas d'accès réseau)*
- `python paris_sportifs_crypto/main.py` *(échec : module `requests` manquant)*
