### PR TITLE
Suppression des données fictives et mise en place de tentatives réseau

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Après la mise en place, vous pouvez lancer un test rapide :
 python paris_sportifs_crypto/main.py
 ```
 
-Ce script affiche des données fictives provenant des modules d'intégration.
-En cas d'absence de connexion, l'appel API renvoie un message d'erreur simulé.
+Ce script tente de récupérer les données de l'API et du site ciblé. En cas
+d'échec réseau, plusieurs essais sont effectués avant d'afficher un message
+d'erreur.
 
 ## Configuration de l'API DeepSeek
 

--- a/paris_sportifs_crypto/backend/api/sportmonks_api.py
+++ b/paris_sportifs_crypto/backend/api/sportmonks_api.py
@@ -3,6 +3,7 @@
 from typing import Any
 from urllib import request, error
 import json
+import time
 
 from ..utils.config import API_KEY
 
@@ -10,16 +11,24 @@ from ..utils.config import API_KEY
 BASE_URL = "https://api.deepseek.com/v1"
 
 
-def fetch_data(endpoint: str) -> dict:
-    """Recupere les données depuis l'API DeepSeek."""
+def fetch_data(endpoint: str, retries: int = 3, delay: float = 2.0) -> dict:
+    """Recupere les données depuis l'API DeepSeek en reessayant en cas d'echec."""
     if not API_KEY:
         return {"endpoint": endpoint, "data": {"error": "cle API manquante"}}
+
     url = f"{BASE_URL}/{endpoint}"
     headers = {"Authorization": f"Bearer {API_KEY}"}
     req = request.Request(url, headers=headers)
-    try:
-        with request.urlopen(req, timeout=10) as resp:
-            data: Any = json.load(resp)
-    except error.URLError:
-        data = {"error": "reseau indisponible"}
-    return {"endpoint": endpoint, "data": data}
+
+    last_error: str | None = None
+    for attempt in range(retries):
+        try:
+            with request.urlopen(req, timeout=10) as resp:
+                data: Any = json.load(resp)
+            return {"endpoint": endpoint, "data": data}
+        except error.URLError as exc:
+            last_error = str(exc.reason)
+            if attempt < retries - 1:
+                time.sleep(delay)
+
+    return {"endpoint": endpoint, "data": {"error": last_error or "reseau indisponible"}}

--- a/paris_sportifs_crypto/backend/api/sportsbet_scraper.py
+++ b/paris_sportifs_crypto/backend/api/sportsbet_scraper.py
@@ -1,7 +1,20 @@
 """Scraper ethique pour Sportsbet.io."""
 
+from urllib import request, error
+import time
 
-def scrape_odds(event_url: str) -> dict:
-    """Retourne des cotes fictives depuis Sportsbet.io."""
-    # TODO: Implementer le scraping réel
-    return {"url": event_url, "odds": []}
+
+def scrape_odds(event_url: str, retries: int = 3, delay: float = 2.0) -> dict:
+    """Recupere les cotes en tentant plusieurs fois en cas d'echec reseau."""
+    for attempt in range(retries):
+        try:
+            with request.urlopen(event_url, timeout=10) as resp:
+                # Le parsing HTML n'est pas encore implémenté
+                html = resp.read().decode("utf-8", "ignore")
+            return {"url": event_url, "html": html}
+        except error.URLError as exc:
+            last_error = str(exc.reason)
+            if attempt < retries - 1:
+                time.sleep(delay)
+
+    return {"url": event_url, "error": last_error or "reseau indisponible"}


### PR DESCRIPTION
## Notes
- Retrait des retours factices lors des échecs réseau
- Ajout de boucles de tentatives dans les appels HTTP

## Summary
- implement retries in `fetch_data` without offline fixtures
- add retry logic in `scrape_odds` and return raw HTML or error
- update README to describe new behavior

## Testing
- `python paris_sportifs_crypto/main.py`