### PR TITLE
Mise à jour endpoint DeepSeek et scraping éthique

### DIFF
--- a/paris_sportifs_crypto/backend/api/sportmonks_api.py
+++ b/paris_sportifs_crypto/backend/api/sportmonks_api.py
@@ -9,9 +9,10 @@ from ..utils.config import API_KEY
 
 
 BASE_URL = "https://api.deepseek.com/v1"
+DEFAULT_ENDPOINT = "football/fixtures"
 
 
-def fetch_data(endpoint: str, retries: int = 3, delay: float = 2.0) -> dict:
+def fetch_data(endpoint: str = DEFAULT_ENDPOINT, retries: int = 3, delay: float = 2.0) -> dict:
     """Recupere les données depuis l'API DeepSeek en reessayant en cas d'echec."""
     if not API_KEY:
         return {"endpoint": endpoint, "data": {"error": "cle API manquante"}}

--- a/paris_sportifs_crypto/backend/api/sportsbet_scraper.py
+++ b/paris_sportifs_crypto/backend/api/sportsbet_scraper.py
@@ -1,16 +1,53 @@
-"""Scraper ethique pour Sportsbet.io."""
+"""Scraper ethique pour Sportsbet.io avec respect du ``robots.txt``."""
 
-from urllib import request, error
+from __future__ import annotations
+
+from pathlib import Path
+from urllib import request, error, parse, robotparser
+import hashlib
 import time
 
 
+USER_AGENT = "ParisCryptoBot/1.0"
+CACHE_DIR = Path(__file__).resolve().parents[2] / "cache"
+
+
+def _is_allowed(url: str, user_agent: str = USER_AGENT) -> bool:
+    """Verifie si ``url`` est autorise par ``robots.txt``."""
+    parsed = parse.urlparse(url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    rp = robotparser.RobotFileParser()
+    rp.set_url(robots_url)
+    try:
+        rp.read()
+    except Exception:
+        return False
+    return rp.can_fetch(user_agent, url)
+
+
+def _cache_path(url: str) -> Path:
+    digest = hashlib.md5(url.encode()).hexdigest()
+    CACHE_DIR.mkdir(exist_ok=True)
+    return CACHE_DIR / f"{digest}.html"
+
+
 def scrape_odds(event_url: str, retries: int = 3, delay: float = 2.0) -> dict:
-    """Recupere les cotes en tentant plusieurs fois en cas d'echec reseau."""
+    """Recupere les cotes en respectant les regles d'acces du site."""
+    if not _is_allowed(event_url):
+        return {"url": event_url, "error": "interdit par robots.txt"}
+
+    cache_file = _cache_path(event_url)
+    if cache_file.is_file():
+        html = cache_file.read_text(encoding="utf-8")
+        return {"url": event_url, "html": html, "cached": True}
+
+    last_error: str | None = None
     for attempt in range(retries):
         try:
-            with request.urlopen(event_url, timeout=10) as resp:
-                # Le parsing HTML n'est pas encore implémenté
+            req = request.Request(event_url, headers={"User-Agent": USER_AGENT})
+            with request.urlopen(req, timeout=10) as resp:
                 html = resp.read().decode("utf-8", "ignore")
+            cache_file.write_text(html, encoding="utf-8")
             return {"url": event_url, "html": html}
         except error.URLError as exc:
             last_error = str(exc.reason)

--- a/paris_sportifs_crypto/main.py
+++ b/paris_sportifs_crypto/main.py
@@ -4,7 +4,7 @@ from backend.api.data_integration import get_combined_data
 
 
 def main() -> None:
-    data = get_combined_data("fixtures", "https://sportsbet.io/event")
+    data = get_combined_data("football/fixtures", "https://sportsbet.io/event")
     print(data)
 
 


### PR DESCRIPTION
## Notes
- Ajout d'un contrôle du `robots.txt`, d'un cache simple et d'un User-Agent dédié dans `sportsbet_scraper.py`.
- Utilisation d'un endpoint réel (`football/fixtures`) pour l'API DeepSeek.
- Mise à jour de `main.py` pour appeler ce nouvel endpoint.

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `python paris_sportifs_crypto/main.py` *(échec réseau attendu)*