### PR TITLE
Améliore setup.sh pour installer les dépendances

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,8 @@ if curl -I https://example.com > /dev/null 2>&1; then
   if [ -f requirements.txt ]; then
     pip3 install -r requirements.txt
   fi
+  # Installation manuelle des bibliotheques utiles
+  pip3 install requests beautifulsoup4 pandas
 else
   echo "[Setup] Aucun acces reseau, dependances non installees"
 fi


### PR DESCRIPTION
## Notes
- `setup.sh` installe maintenant explicitement `requests`, `beautifulsoup4` et `pandas` lorsque le réseau est accessible.
- Les tests se limitent à l'exécution de `python paris_sportifs_crypto/main.py` car aucun test automatisé n'est fourni.

## Résumé
- script d'installation mis à jour pour installer les bibliothèques nécessaires.
